### PR TITLE
Fix service account key type

### DIFF
--- a/plugins/lookup/compute_images.py
+++ b/plugins/lookup/compute_images.py
@@ -22,8 +22,8 @@ DOCUMENTATION = """
       type: string
       description: 
     service_account_key:
-      type: string
-      description: 
+      type: dict
+      description: dictionary with contents of service account key JSON
     token:
       type: string
       description: 

--- a/plugins/lookup/vpc_subnets.py
+++ b/plugins/lookup/vpc_subnets.py
@@ -18,8 +18,8 @@ DOCUMENTATION = """
       type: string
       description: 
     service_account_key:
-      type: string
-      description: 
+      type: dict
+      description: dictionary with contents of service account key JSON
     token:
       type: string
       description: 

--- a/plugins/modules/compute_disk.py
+++ b/plugins/modules/compute_disk.py
@@ -104,9 +104,25 @@ DOCUMENTATION = """
         - An IAM token is a unique sequence of characters issued to a user after authentication.
         - The following regular expression describes a token: C(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})
     service_account_key:
-      type: str
+      type: dict
       description:
         - A Service Account Key.
+      suboptions:
+        id:
+          type: str
+          description:
+            - Key object ID
+            - "id" field from service account key JSON
+        service_account_id:
+          type: str
+          description:
+            - Service account ID
+            - "service_account_id" field from service account key JSON
+        private_key:
+          type: str
+          description:
+            - Private key
+            - "private_key" field from service account key JSON
     token:
       type: str
       description:
@@ -414,7 +430,7 @@ def main():
             # disk_placement_policy=dict(),
             # snapshot_schedule_ids=dict(type='list'),
             iam_token=dict(type='str', no_log=True),
-            service_account_key=dict(type='str', no_log=True),
+            service_account_key=dict(type='dict', no_log=True),
             token=dict(type='str', no_log=True),
         ),
         required_one_of=[('iam_token', 'service_account_key', 'token')],

--- a/plugins/modules/compute_instance.py
+++ b/plugins/modules/compute_instance.py
@@ -938,7 +938,7 @@ def main():
             maintenance_grace_period=dict(type='int'),
             iam_token=dict(type='str'),
             token=dict(type='str'),
-            service_account_key=dict(type='str'),
+            service_account_key=dict(type='dict'),
         ),
         required_one_of=[('iam_token', 'token', 'service_account_key')],
         required_if=[

--- a/plugins/modules/compute_instance.py
+++ b/plugins/modules/compute_instance.py
@@ -453,9 +453,25 @@ DOCUMENTATION = """
         - An IAM token is a unique sequence of characters issued to a user after authentication.
         - The following regular expression describes a token: C(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})
     service_account_key:
-      type: str
+      type: dict
       description:
         - A Service Account Key.
+      suboptions:
+        id:
+          type: str
+          description:
+            - Key object ID
+            - "id" field from service account key JSON
+        service_account_id:
+          type: str
+          description:
+            - Service account ID
+            - "service_account_id" field from service account key JSON
+        private_key:
+          type: str
+          description:
+            - Private key
+            - "private_key" field from service account key JSON
     token:
       type: str
       description:


### PR DESCRIPTION
API awaits service account key as dict with contents of JSON key file.

```
RuntimeError: Invalid Service Account Key: expecting dictionary, actually got <class 'str'>
```

